### PR TITLE
Change back to Debian and bump to 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.13.9-alpine
+FROM nginx:1.17
 
 COPY default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This PR:

- changes this container (back) from Alpine 3.7 to Debian (10, apparently)
- bumps the nginx version from 1.13.9 to 1.17.2